### PR TITLE
Reformated files, make picklable and encourage to import Attridict

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,12 @@ pip install attridict
 ```
 
 
-
-
 ## Usage
 
 Creating an attridict object
 ```python
->>> import attridict
->>> att = attridict()
+>>> from attridict import AttriDict
+>>> att = AttriDict()
 >>> att
 {}
 >>> att.foo = "bar"
@@ -32,15 +30,24 @@ Creating an attridict object
 >>> att
 {'foo': 'bar'}
 ```
-<br/>
+
+For backward compatibility, the project old import style is still usable.
+
+```
+>>> import attridict
+>>> att = attridict()
+>>> att
+{}
+```
+
 
 A dict can be converted into an attridict object by passing it as an argument
 ```python
->>> import attridict
+>>> from attridict import AttriDict
 
 >>> data = {'red': 'hot', 'blue': 'cold'}
 
->>> colors = attridict(data)
+>>> colors = AttriDict(data)
 >>> colors
 {'red': 'hot', 'blue': 'cold'}
 
@@ -51,11 +58,11 @@ A dict can be converted into an attridict object by passing it as an argument
 
 Modifying attridict object
 ```python
->>> import attridict
+>>> from attridict import AttriDict
 
 >>> data = {'red': 'hot', 'blue': 'cold'}
 
->>> colors = attridict(data)
+>>> colors = AttriDict(data)
 >>> colors
 {'red': 'hot', 'blue': 'cold'}
 
@@ -79,11 +86,11 @@ Modifying attridict object
 
 Typical `dict` operations work on attridict objects
 ```python
->>> import attridict
+>>> from attridict import AttriDict
 
 >>> data = {'red': 'rose', 'blue': 'sky'}
 
->>> colors = attridict(data)
+>>> colors = AttriDict(data)
 >>> colors
 {'red': 'rose', 'blue': 'sky'}
 
@@ -102,10 +109,10 @@ Typical `dict` operations work on attridict objects
 
 Nested attribute access
 ```python
->>> import attridict
+>>> from attridict import AttriDict
 
 >>> data = {'foo': {}}
->>> att = attridict(data)
+>>> att = AttriDict(data)
 
 >>> att
 {'foo': {}}

--- a/attridict.py
+++ b/attridict.py
@@ -5,9 +5,12 @@
 
 __author__ = "Alvin Shaita"
 __email__ = "alvinshaita@gmail.com"
+__version__ = "0.0.7"
 
 import types
 from mixins import MapMixin
+
+__all__ = ["AttriDict"]
 
 
 class _AttriDict(types.ModuleType):
@@ -17,10 +20,6 @@ class _AttriDict(types.ModuleType):
 
 class AttriDict(dict, MapMixin):
     """AttriDict"""
-
-    __version__ = "0.0.7"
-
-    __all__ = ["to_dict"]
 
     def __init__(self, *args, **kwargs):
         if args and not isinstance(*args, dict):

--- a/attridict.py
+++ b/attridict.py
@@ -10,12 +10,12 @@ import types
 from mixins import MapMixin
 
 
-class AttriDict(types.ModuleType):
+class _AttriDict(types.ModuleType):
     def __call__(self, *args, **kwargs):
-        return _AttriDict(*args, **kwargs)
+        return AttriDict(*args, **kwargs)
 
 
-class _AttriDict(dict, MapMixin):
+class AttriDict(dict, MapMixin):
     """AttriDict"""
 
     __version__ = "0.0.7"
@@ -59,4 +59,4 @@ class _AttriDict(dict, MapMixin):
 if __name__ == "attridict":
     import sys
 
-    sys.modules[__name__].__class__ = AttriDict
+    sys.modules[__name__].__class__ = _AttriDict

--- a/attridict.py
+++ b/attridict.py
@@ -1,59 +1,62 @@
-'''
-	attridict.py:
-		Alvin Shaita <alvinshaita@gmail.com>
-'''
+"""
+    attridict.py:
+        Alvin Shaita <alvinshaita@gmail.com>
+"""
 
-__author__	= "Alvin Shaita"
-__email__	= "alvinshaita@gmail.com"
+__author__ = "Alvin Shaita"
+__email__ = "alvinshaita@gmail.com"
 
+import types
 from mixins import MapMixin
 
 
-__all__ = ["AttriDict"]
+class AttriDict(types.ModuleType):
+    def __call__(self, *args, **kwargs):
+        return _AttriDict(*args, **kwargs)
 
-class AttriDict(dict, MapMixin):
-	'''AttriDict'''
 
-	__version__ = "0.0.7"
+class _AttriDict(dict, MapMixin):
+    """AttriDict"""
 
-	__all__ = ["to_dict"]
+    __version__ = "0.0.7"
 
-	def __init__(self, *args, **kwargs):
-		if args and not isinstance(*args, dict):
-			raise AttributeError(
-				"non dict argument provided"
-			)
+    __all__ = ["to_dict"]
 
-		super(type(self), self).__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        if args and not isinstance(*args, dict):
+            raise AttributeError(
+                "non dict argument provided"
+            )
+        super().__init__(*args, **kwargs)
 
-	def _attrify(self, obj):
-		"""
-		Convert dict instance objects to attridict
-		"""
-		if isinstance(obj, dict):
-			obj = type(self)(obj)
-		elif isinstance(obj, (list, set, tuple)):
-			obj = type(obj)(self._attrify(i) for i in obj)
+    def _attrify(self, obj):
+        """
+        Convert dict instance objects to attridict
+        """
+        if isinstance(obj, dict):
+            obj = type(self)(obj)
+        elif isinstance(obj, (list, set, tuple)):
+            obj = type(obj)(self._attrify(i) for i in obj)
 
-		return obj
+        return obj
 
-	def _valid_key(self, key):
-		"""
-		Check if the key provided is a valid key
-		"""
-		if key in dir(self):
-			return False
+    def _valid_key(self, key):
+        """
+        Check if the key provided is a valid key
+        """
+        if key in dir(self):
+            return False
 
-		return True
+        return True
 
-	def to_dict(self):
-		"""
-		Return a dict equivalent of the attridict object
-		"""
-		return dict(self)
-
+    def to_dict(self):
+        """
+        Return a dict equivalent of the attridict object
+        """
+        return dict(self)
 
 
 if __name__ == "attridict":
-	import sys
-	sys.modules[__name__] = AttriDict
+    import sys
+
+    sys.modules[__name__].__class__ = AttriDict

--- a/mixins.py
+++ b/mixins.py
@@ -1,86 +1,88 @@
 from abc import ABC, abstractmethod
 
+
 def assign_self(func):
-	"""
-	Set the received object the value of the key in the mapping container
-	"""
-	def wrapper(container, key):
-		new_object = func(container, key)
-		container[key] = new_object
-		return container[key]
-	
-	return wrapper
+    """
+    Set the received object the value of the key in the mapping container
+    """
+
+    def wrapper(container, key):
+        new_object = func(container, key)
+        container[key] = new_object
+        return container[key]
+
+    return wrapper
 
 
 __all__ = ["MapMixin"]
 
+
 class MapMixin(ABC):
 
-	@abstractmethod
-	def _valid_key(self, key):
-		pass
+    @abstractmethod
+    def _valid_key(self, key):
+        pass
 
-	@abstractmethod
-	def _attrify(self, key):
-		pass
+    @abstractmethod
+    def _attrify(self, key):
+        pass
 
+    @assign_self
+    def __call__(self, key):
+        """
+        Access value through object call
+            eg. att(key)
+        """
+        obj = self[key]
+        return self._attrify(obj)
 
-	@assign_self
-	def __call__(self, key):
-		"""
-		Access value through object call
-			eg. att(key)
-		"""
-		obj = self[key]
-		return self._attrify(obj)
+    @assign_self
+    def __getattr__(self, key):
+        """
+        Accesss value via attribute
+        """
+        if not self._valid_key(key):
+            raise AttributeError(
+                "invalid key, '{key}'".format(key=key)
+            )
 
-	@assign_self
-	def __getattr__(self, key):
-		"""
-		Accesss value via attribute
-		"""
-		if not self._valid_key(key):
-			raise AttributeError(
-				"invalid key, '{key}'".format(key=key)
-			)
+        if key not in self:
+            raise AttributeError(
+                "key does not exist, '{key}'".format(key=key)
+            )
 
-		if key not in self:
-			raise AttributeError(
-				"key does not exist, '{key}'".format(key=key)
-			)
+        obj = self[key]
+        return self._attrify(obj)
 
-		obj = self[key]
-		return self._attrify(obj)
+    def __setattr__(self, key, value):
+        if not self._valid_key(key):
+            raise AttributeError(
+                "invalid key, '{key}'".format(key=key)
+            )
 
-	def __setattr__(self, key, value):
-		if not self._valid_key(key):
-			raise AttributeError(
-				"invalid key, '{key}'".format(key=key)
-			)
+        self[key] = value
 
-		self[key] = value
+    def __delattr__(self, key):
+        del self[key]
 
-	def __delattr__(self, key):
-		del self[key]
+    def __add__(self, other):
+        """
+        Add a dict, or its child to an attridict object
+        """
+        if not isinstance(other, dict):
+            raise TypeError(
+                "'{other}' is not a mapping object".format(other=other)
+            )
 
-	def __add__(self, other):
-		"""
-		Add a dict, or its child to an attridict object
-		"""
-		if not isinstance(other, dict):
-			raise TypeError(
-				"'{other}' is not a mapping object".format(other=other)
-			)
+        return type(self)({**self, **other})
 
-		return type(self)({**self, **other})
+    def __radd__(self, other):
+        """
+        Add an attridict object to a dict, or its child
+        """
+        if not isinstance(other, dict):
+            raise TypeError(
+                "'{other}' is not a mapping object".format(other=other)
+            )
 
-	def __radd__(self, other):
-		"""
-		Add an attridict object to a dict, or its child
-		"""
-		if not isinstance(other, dict):
-			raise TypeError(
-				"'{other}' is not a mapping object".format(other=other)
-			)
-
-		return type(self)({**other, **self})
+        return type(self)({**other, **self})

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-'''
+"""
 python setup.py install
-'''
+"""
 
 from setuptools import setup
 
@@ -10,23 +10,23 @@ readme = open("README.md", 'r')
 long_description = readme.read()
 
 setup(
-	name="attridict",
-	version=attridict.__version__,
-	author="Alvin Shaita",
-	author_email="alvinshaita@gmail.com",
-	url="https://github.com/alvinshaita/attridict",
-	license="MIT License",
-	packages=["."],
-	keywords="attridict, attrdict, struct, dict, dot, attribute, attributes, dictionary, attr",
-	description="A dict implementation with support for easy and clean access of its values through attributes",
-	long_description=long_description,
-	long_description_content_type='text/markdown',
-	classifiers=[
-		"Intended Audience :: Developers",
-		"License :: OSI Approved :: MIT License",
-		"Programming Language :: Python :: 2",
-        	"Programming Language :: Python :: 3",
-        	"Programming Language :: Python :: Implementation :: CPython",
-        	"Programming Language :: Python :: Implementation :: PyPy",
-	]
+    name="attridict",
+    version=attridict.__version__,
+    author="Alvin Shaita",
+    author_email="alvinshaita@gmail.com",
+    url="https://github.com/alvinshaita/attridict",
+    license="MIT License",
+    packages=["."],
+    keywords="attridict, attrdict, struct, dict, dot, attribute, attributes, dictionary, attr",
+    description="A dict implementation with support for easy and clean access of its values through attributes",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+    ]
 )

--- a/tests.py
+++ b/tests.py
@@ -10,6 +10,16 @@ import attridict
 
 
 class TestAttriDict(unittest.TestCase):
+
+    def test_import_class(self):
+        from attridict import AttriDict
+        att = AttriDict()
+        self.assertEqual(att, {})
+
+        att.one = 111
+        self.assertEqual(att.one, 111)
+        self.assertEqual(att, {"one": 111})
+
     def test_attridict(self):
         # test growth through assignment
         att = attridict()
@@ -205,12 +215,18 @@ class TestAttriDict(unittest.TestCase):
         self.assertEqual(getattr(att, "one", 333), 111)
         self.assertEqual(getattr(att, "three", 333), 333)
 
-    def test_picklable(self):
+    def test_pickable(self):
         import pickle
+        from attridict import AttriDict
         data = {"one": 111, "two": 222}
         att = attridict(data)
         picked = pickle.dumps(att)
 
+        unpicked = pickle.loads(picked)
+        self.assertEqual(att, unpicked)
+
+        att = AttriDict(data)
+        picked = pickle.dumps(att)
         unpicked = pickle.loads(picked)
         self.assertEqual(att, unpicked)
 

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
-'''
+"""
 python -m unittest tests.py
-'''
+"""
 
 import unittest
 
@@ -10,218 +10,210 @@ import attridict
 
 
 class TestAttriDict(unittest.TestCase):
-	def test_attridict(self):
-		# test growth through assignment
-		att = attridict()
-		self.assertEqual(att, {})
+    def test_attridict(self):
+        # test growth through assignment
+        att = attridict()
+        self.assertEqual(att, {})
 
-		att.one = 111
-		self.assertEqual(att.one, 111)
-		self.assertEqual(att, {"one": 111})
+        att.one = 111
+        self.assertEqual(att.one, 111)
+        self.assertEqual(att, {"one": 111})
 
-		att.two = {"three": 333}
-		self.assertEqual(att.two, {"three": 333})
-		self.assertEqual(att, {"one": 111, "two": {"three": 333}})
+        att.two = {"three": 333}
+        self.assertEqual(att.two, {"three": 333})
+        self.assertEqual(att, {"one": 111, "two": {"three": 333}})
 
-		att.two.four = {"five": 555, "six": 666}
-		self.assertEqual(att.two.four.five, 555)
-		self.assertEqual(att.two.four.six, 666)
+        att.two.four = {"five": 555, "six": 666}
+        self.assertEqual(att.two.four.five, 555)
+        self.assertEqual(att.two.four.six, 666)
 
-		self.assertEqual(att, {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}})
+        self.assertEqual(att, {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}})
 
+    def test_attridict2(self):
+        # test conversion from dict
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
 
-	def test_attridict2(self):
-		# test conversion from dict
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
+        self.assertEqual(att.one, 111)
+        self.assertEqual(att.two, {"three": 333, "four": {"five": 555, "six": 666}})
+        self.assertEqual(att.two.three, 333)
+        self.assertEqual(att.two.four, {"five": 555, "six": 666})
+        self.assertEqual(att.two.four.five, 555)
+        self.assertEqual(att.two.four.six, 666)
 
-		self.assertEqual(att.one, 111)
-		self.assertEqual(att.two, {"three": 333, "four": {"five": 555, "six": 666}})
-		self.assertEqual(att.two.three, 333)
-		self.assertEqual(att.two.four, {"five": 555, "six": 666})
-		self.assertEqual(att.two.four.five, 555)
-		self.assertEqual(att.two.four.six, 666)
+        # test reassignment of assigned values
+        att.two = 222
+        self.assertEqual(att.two, 222)
 
-		# test reassignment of assigned values
-		att.two = 222
-		self.assertEqual(att.two, 222)
+        att.three = {"four": 444, "five": 555}
+        self.assertEqual(att.three, {"four": 444, "five": 555})
+        self.assertEqual(att, {"one": 111, "two": 222, "three": {"four": 444, "five": 555}})
 
-		att.three = {"four": 444, "five": 555}
-		self.assertEqual(att.three, {"four": 444, "five": 555})
-		self.assertEqual(att, {"one": 111, "two": 222, "three": {"four": 444, "five": 555}})
+    def test_attridict3(self):
+        # test value conservativity of converted dict
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
 
+        self.assertEqual(att, data)
+        self.assertEqual(att.one, data["one"])
+        self.assertEqual(att.two, data["two"])
+        self.assertEqual(att.two.three, data["two"]["three"])
+        self.assertEqual(att.two.four, data["two"]["four"])
+        self.assertEqual(att.two.four.five, data["two"]["four"]["five"])
+        self.assertEqual(att.two.four.six, data["two"]['four']["six"])
 
-	def test_attridict3(self):
-		# test value conservativity of converted dict
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
+    def test_attridict5(self):
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
+        att.three = {"four": 444, "five": 565}
 
-		self.assertEqual(att, data)
-		self.assertEqual(att.one, data["one"])
-		self.assertEqual(att.two, data["two"])
-		self.assertEqual(att.two.three, data["two"]["three"])
-		self.assertEqual(att.two.four, data["two"]["four"])
-		self.assertEqual(att.two.four.five, data["two"]["four"]["five"])
-		self.assertEqual(att.two.four.six, data["two"]['four']["six"])
+        del att
 
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
 
-	def test_attridict5(self):
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
-		att.three = {"four": 444, "five": 565}
+        self.assertEqual(data.__len__(), att.__len__())
+        self.assertEqual(data["two"].__len__(), att.two.__len__())
+        self.assertEqual(data["two"]["four"].__len__(), att.two.four.__len__())
 
-		del att
+    def test_attridict6(self):
+        # test equality of attridict and initialized dict
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
+        self.assertEqual(att, data)
 
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
+    def test_mutable(self):
+        # test mutability of an attridict object
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
+        att_mutable = att
+        att.two = 222
+        self.assertEqual(att, att_mutable)
+        self.assertIs(att, att_mutable)
 
-		self.assertEqual(data.__len__(), att.__len__())
-		self.assertEqual(data["two"].__len__(), att.two.__len__())
-		self.assertEqual(data["two"]["four"].__len__(), att.two.four.__len__())
+    def test_copy(self):
+        # test attridict copy is not equal to original
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
+        att_copy = att.copy()
 
+        self.assertIsNot(att, att_copy)
 
-	def test_attridict6(self):
-		# test equality of attridict and initialized dict
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
-		self.assertEqual(att, data)
+        att.two = 222
+        self.assertNotEqual(att, att_copy)
+        self.assertEqual(att_copy, data)
 
+    def test_to_dict(self):
+        # test to_dict() returns dict
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
 
-	def test_mutable(self):
-		# test mutability of an attridict object
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
-		att_mutable = att
-		att.two = 222
-		self.assertEqual(att, att_mutable)
-		self.assertIs(att, att_mutable)
+        att_dict = att.to_dict()
+        self.assertEqual(data, att_dict)
 
+        self.assertEqual(type(att_dict), dict)
+        self.assertEqual(type(att_dict["two"]), dict)
+        self.assertEqual(type(att_dict["two"]["four"]), dict)
 
-	def test_copy(self):
-		# test attridict copy is not equal to original
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
-		att_copy = att.copy()
-		
-		self.assertIsNot(att, att_copy)
+    def test_attridict10(self):
+        # test del deletes attribute
+        data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
+        att = attridict(data)
 
-		att.two = 222
-		self.assertNotEqual(att, att_copy)
-		self.assertEqual(att_copy, data)
+        del att.two.four.six
+        self.assertEqual(att, {"one": 111, "two": {"three": 333, "four": {"five": 555}}})
 
+    def test_attridict11(self):
+        data = {}
+        data["me"] = data
 
-	def test_to_dict(self):
-		# test to_dict() returns dict
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
+        att = attridict(data)
 
-		att_dict = att.to_dict()
-		self.assertEqual(data, att_dict)
+        self.assertEqual(att, data)
+        self.assertEqual(att.me, data)
+        self.assertEqual(att.me.me, data)
 
-		self.assertEqual(type(att_dict), dict)
-		self.assertEqual(type(att_dict["two"]), dict)
-		self.assertEqual(type(att_dict["two"]["four"]), dict)
+    def test_attridict12(self):
+        one = {"one": "me"}
+        two = {"two": "me"}
 
+        one["two"] = two
+        two["one"] = one
 
-	def test_attridict10(self):
-		# test del deletes attribute
-		data = {"one": 111, "two": {"three": 333, "four": {"five": 555, "six": 666}}}
-		att = attridict(data)
+        att_one = attridict(one)
+        att_two = attridict(two)
 
-		del att.two.four.six
-		self.assertEqual(att, {"one": 111, "two": {"three": 333, "four": {"five": 555}}})
+        self.assertEqual(att_one.one, "me")
+        self.assertEqual(att_one.two, two)
+        self.assertEqual(att_one.two, att_two)
 
+        self.assertEqual(att_two.two, "me")
+        self.assertEqual(att_two.one, one)
+        self.assertEqual(att_two.one, att_one)
 
+    def test_attridict14(self):
+        data = {"one": 111, "two": [1, 2, 3], "three": {4, 5, 6}, "four": (7, 8, 9)}
 
-	def test_attridict11(self):
-		data = {}
-		data["me"] = data
+        att = attridict(data)
 
-		att = attridict(data)
+        self.assertEqual(att, data)
+        self.assertEqual(att.two, [1, 2, 3])
+        self.assertEqual(att.three, {4, 5, 6})
+        self.assertEqual(att.four, (7, 8, 9))
 
-		self.assertEqual(att, data)
-		self.assertEqual(att.me, data)
-		self.assertEqual(att.me.me, data)
+    def test_call(self):
+        # test object call with key argument returns corresponding value
+        data = {"one": 111, "two": {"three": 333}}
 
+        att = attridict(data)
 
-	def test_attridict12(self):
-		one = {"one": "me"}
-		two = {"two": "me"}
+        self.assertEqual(att("one"), 111)
+        self.assertEqual(att("two"), {"three": 333})
+        self.assertEqual(att.two("three"), 333)
 
-		one["two"] = two
-		two["one"] = one
+    def test_add(self):
+        # test adding dict object and attridict object together
+        data1 = {"one": 111, "two": 222}
+        att1 = attridict(data1)
 
-		att_one = attridict(one)
-		att_two = attridict(two)
+        data2 = {"three": 333, "four": 444}
+        att2 = attridict(data2)
 
-		self.assertEqual(att_one.one, "me")
-		self.assertEqual(att_one.two, two)
-		self.assertEqual(att_one.two, att_two)
+        self.assertEqual(att1 + data2, {"one": 111, "two": 222, "three": 333, "four": 444})
+        self.assertEqual(data1 + att2, {"one": 111, "two": 222, "three": 333, "four": 444})
+        self.assertEqual(att1 + att2, {"one": 111, "two": 222, "three": 333, "four": 444})
 
-		self.assertEqual(att_two.two, "me")
-		self.assertEqual(att_two.one, one)
-		self.assertEqual(att_two.one, att_one)
+    def test_kwargs(self):
+        data = {"one": 111, "two": 222}
 
+        att = attridict(data, three=333, four=444)
+        self.assertEqual(att, {"one": 111, "two": 222, "three": 333, "four": 444})
 
-	def test_attridict14(self):
-		data = {"one": 111, "two": [1,2,3], "three": {4,5,6}, "four": (7,8,9)}
+    def test_kwargs_overwrite(self):
+        # test keyword argument overwrites original argument
+        data = {"one": 111, "two": 222}
 
-		att = attridict(data)
+        att = attridict(data, two=333)
+        self.assertEqual(att, {"one": 111, "two": 333})
 
-		self.assertEqual(att, data)
-		self.assertEqual(att.two, [1,2,3])
-		self.assertEqual(att.three, {4,5,6})
-		self.assertEqual(att.four, (7,8,9))
+    def test_getattr(self):
+        # test getattr function returns expected output
+        data = {"one": 111, "two": 222}
+        att = attridict(data)
 
+        self.assertEqual(getattr(att, "one"), 111)
+        self.assertEqual(getattr(att, "one", 333), 111)
+        self.assertEqual(getattr(att, "three", 333), 333)
 
-	def test_call(self):
-		# test object call with key argument returns corresponding value
-		data = {"one": 111, "two": {"three": 333}}
+    def test_picklable(self):
+        import pickle
+        data = {"one": 111, "two": 222}
+        att = attridict(data)
+        picked = pickle.dumps(att)
 
-		att = attridict(data)
-
-		self.assertEqual(att("one"), 111)
-		self.assertEqual(att("two"), {"three": 333})
-		self.assertEqual(att.two("three"), 333)
-
-
-	def test_add(self):
-		# test adding dict object and attridict object together
-		data1 = {"one": 111, "two": 222}
-		att1 = attridict(data1)
-
-		data2 = {"three": 333, "four": 444}
-		att2 = attridict(data2)
-		
-		self.assertEqual(att1 + data2, {"one": 111, "two": 222, "three": 333, "four": 444})
-		self.assertEqual(data1 + att2, {"one": 111, "two": 222, "three": 333, "four": 444})
-		self.assertEqual(att1 + att2, {"one": 111, "two": 222, "three": 333, "four": 444})
-
-
-	def test_kwargs(self):
-		data = {"one": 111, "two": 222}
-
-		att = attridict(data, three=333, four=444)
-		self.assertEqual(att, {"one":111, "two":222, "three": 333, "four": 444})
-
-
-	def test_kwargs_overwrite(self):
-		# test keyword argument overwrites original argument
-		data = {"one": 111, "two": 222}
-
-		att = attridict(data, two=333)
-		self.assertEqual(att, {"one": 111, "two": 333})
-
-
-	def test_getattr(self):
-		# test getattr function returns expected output
-		data = {"one": 111, "two": 222}
-		att = attridict(data)
-
-		self.assertEqual(getattr(att, "one"), 111)
-		self.assertEqual(getattr(att, "one", 333), 111)
-		self.assertEqual(getattr(att, "three", 333), 333)
+        unpicked = pickle.loads(picked)
+        self.assertEqual(att, unpicked)
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()


### PR DESCRIPTION
**Changes**

- Reformated files (space indent, PEP8, etc)
- `from attridict import AttriDict` can be used
- AttriDict can be `pickled`
